### PR TITLE
Convert PySpark Window Functions Demos to Spark Connect

### DIFF
--- a/src/py/window_funcs/README.md
+++ b/src/py/window_funcs/README.md
@@ -2,7 +2,9 @@
 
 Window functions are one of the most powerful yet underutilized features in PySpark. Unlike regular aggregations that collapse your data into summary rows, window functions perform calculations across related rows while preserving the original dataset structure. This makes them perfect for analytics tasks like ranking, running totals, trend analysis, and customer journey mapping.
 
-In this comprehensive guide, we'll explore six essential window function patterns through practical, real-world examples. Each demo is designed to be simple, digestible, and ready for production use.
+In this comprehensive guide, we'll explore six essential window function patterns through practical, real-world examples. Each demo is designed to be simple, digestible, and ready to use.
+
+> ⚡ **All demos use Spark Connect** with modern architecture for Spark 4.0+ environments.
 
 ## 🎯 What Are Window Functions?
 
@@ -308,17 +310,45 @@ df_attribution = (df.withColumn("first_touch_channel", first("channel").over(win
 
 ## 🚀 Getting Started
 
-Each demo file is standalone and ready to run:
+All demos are built using **Spark Connect**. Each demo file is standalone and ready to run:
 
 ```bash
-# Run any demo
+# Run individual demos directly
 python ranking_operations_demo.py
 python aggregation_window_demo.py
 python lead_lag_demo.py
 python moving_averages_demo.py
 python percentile_analysis_demo.py
 python first_last_value_demo.py
+
+# Or use the convenient runner script
+python run_demo.py ranking
+python run_demo.py aggregation
+python run_demo.py lead_lag
+python run_demo.py moving_averages
+python run_demo.py percentile
+python run_demo.py first_last_value
+
+# List all available demos
+python run_demo.py --list
 ```
+
+### ⚡ Spark Connect Configuration
+
+All demos use **Spark Connect** with the following configuration:
+
+```python
+spark = SparkSession.builder \
+    .appName("WindowFunctionDemo") \
+    .config("spark.api.mode", "connect") \
+    .remote("local[*]") \
+    .getOrCreate()
+```
+
+**Benefits of Spark Connect:**
+- Better separation between client and server processes
+- Modern architecture for Spark 4.0+
+- Simplified configuration and setup
 
 ### Prerequisites
 
@@ -326,6 +356,9 @@ python first_last_value_demo.py
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import *
 from pyspark.sql.window import Window
+
+# Spark Connect is included in PySpark 4.0+
+# No additional setup required for local development
 ```
 
 ## 💡 Key Takeaways

--- a/src/py/window_funcs/aggregation_window_demo.py
+++ b/src/py/window_funcs/aggregation_window_demo.py
@@ -34,6 +34,8 @@ BUSINESS SCENARIOS COVERED:
 • Progressive performance tracking
 
 Usage: python aggregation_window_demo.py
+
+NOTE: This demo uses Spark Connect.
 """
 
 from pyspark.sql import SparkSession
@@ -175,14 +177,15 @@ def real_world_example(df):
     final_summary.show(truncate=False)
 
 if __name__ == "__main__":
-    # Initialize Spark
+    # Initialize Spark Connect
     spark = SparkSession.builder \
         .appName("AggregationWindowDemo") \
-        .master("local[*]") \
-        .config("spark.sql.adaptive.enabled", "true") \
+        .config("spark.api.mode", "connect") \
+        .remote("local[*]") \
         .getOrCreate()
     
-    spark.sparkContext.setLogLevel("ERROR")
+    # Note: spark.sparkContext is not available in Spark Connect
+    # Log level configuration is handled server-side
     
     # Create sample data
     df = create_daily_sales_data(spark)

--- a/src/py/window_funcs/first_last_value_demo.py
+++ b/src/py/window_funcs/first_last_value_demo.py
@@ -34,6 +34,8 @@ BUSINESS SCENARIOS COVERED:
 • Customer journey optimization insights
 
 Usage: python first_last_value_demo.py
+
+NOTE: This demo uses Spark Connect.
 """
 
 from pyspark.sql import SparkSession
@@ -196,14 +198,15 @@ def real_world_example(df):
                   .show(truncate=False)
 
 if __name__ == "__main__":
-    # Initialize Spark
+    # Initialize Spark Connect
     spark = SparkSession.builder \
         .appName("FirstLastValueDemo") \
-        .master("local[*]") \
-        .config("spark.sql.adaptive.enabled", "true") \
+        .config("spark.api.mode", "connect") \
+        .remote("local[*]") \
         .getOrCreate()
     
-    spark.sparkContext.setLogLevel("ERROR")
+    # Note: spark.sparkContext is not available in Spark Connect
+    # Log level configuration is handled server-side
     
     # Create sample data
     df = create_customer_journey_data(spark)

--- a/src/py/window_funcs/lead_lag_demo.py
+++ b/src/py/window_funcs/lead_lag_demo.py
@@ -34,6 +34,8 @@ BUSINESS SCENARIOS COVERED:
 • Financial time series monitoring
 
 Usage: python lead_lag_demo.py
+
+NOTE: This demo uses Spark Connect.
 """
 
 from pyspark.sql import SparkSession
@@ -186,14 +188,15 @@ def real_world_example(df):
     signal_summary.show(truncate=False)
 
 if __name__ == "__main__":
-    # Initialize Spark
+    # Initialize Spark Connect
     spark = SparkSession.builder \
         .appName("LeadLagDemo") \
-        .master("local[*]") \
-        .config("spark.sql.adaptive.enabled", "true") \
+        .config("spark.api.mode", "connect") \
+        .remote("local[*]") \
         .getOrCreate()
     
-    spark.sparkContext.setLogLevel("ERROR")
+    # Note: spark.sparkContext is not available in Spark Connect
+    # Log level configuration is handled server-side
     
     # Create sample data
     df = create_stock_price_data(spark)

--- a/src/py/window_funcs/moving_averages_demo.py
+++ b/src/py/window_funcs/moving_averages_demo.py
@@ -34,6 +34,8 @@ BUSINESS SCENARIOS COVERED:
 • Alert generation based on moving average thresholds
 
 Usage: python moving_averages_demo.py
+
+NOTE: This demo uses Spark Connect.
 """
 
 from pyspark.sql import SparkSession
@@ -206,14 +208,15 @@ def real_world_example(df):
     performance_summary.show(truncate=False)
 
 if __name__ == "__main__":
-    # Initialize Spark
+    # Initialize Spark Connect
     spark = SparkSession.builder \
         .appName("MovingAveragesDemo") \
-        .master("local[*]") \
-        .config("spark.sql.adaptive.enabled", "true") \
+        .config("spark.api.mode", "connect") \
+        .remote("local[*]") \
         .getOrCreate()
     
-    spark.sparkContext.setLogLevel("ERROR")
+    # Note: spark.sparkContext is not available in Spark Connect
+    # Log level configuration is handled server-side
     
     # Create sample data
     df = create_daily_sales_data(spark)

--- a/src/py/window_funcs/percentile_analysis_demo.py
+++ b/src/py/window_funcs/percentile_analysis_demo.py
@@ -34,6 +34,8 @@ BUSINESS SCENARIOS COVERED:
 • Performance-based promotion and compensation recommendations
 
 Usage: python percentile_analysis_demo.py
+
+NOTE: This demo uses Spark Connect.
 """
 
 from pyspark.sql import SparkSession
@@ -220,14 +222,15 @@ def real_world_example(df):
     dept_summary.show(truncate=False)
 
 if __name__ == "__main__":
-    # Initialize Spark
+    # Initialize Spark Connect
     spark = SparkSession.builder \
         .appName("PercentileAnalysisDemo") \
-        .master("local[*]") \
-        .config("spark.sql.adaptive.enabled", "true") \
+        .config("spark.api.mode", "connect") \
+        .remote("local[*]") \
         .getOrCreate()
     
-    spark.sparkContext.setLogLevel("ERROR")
+    # Note: spark.sparkContext is not available in Spark Connect
+    # Log level configuration is handled server-side
     
     # Create sample data
     df = create_employee_salary_data(spark)

--- a/src/py/window_funcs/ranking_operations_demo.py
+++ b/src/py/window_funcs/ranking_operations_demo.py
@@ -33,6 +33,8 @@ BUSINESS SCENARIOS COVERED:
 • Multi-level ranking comparisons
 
 Usage: python ranking_operations_demo.py
+
+NOTE: This demo uses Spark Connect.
 """
 
 from pyspark.sql import SparkSession
@@ -213,14 +215,15 @@ def real_world_example(df):
     summary.show(truncate=False)
 
 if __name__ == "__main__":
-    # Initialize Spark
+    # Initialize Spark Connect
     spark = SparkSession.builder \
         .appName("RankingOperationsDemo") \
-        .master("local[*]") \
-        .config("spark.sql.adaptive.enabled", "true") \
+        .config("spark.api.mode", "connect") \
+        .remote("local[*]") \
         .getOrCreate()
     
-    spark.sparkContext.setLogLevel("ERROR")
+    # Note: spark.sparkContext is not available in Spark Connect
+    # Log level configuration is handled server-side
     
     # Create sample data
     df = create_sales_data(spark)

--- a/src/py/window_funcs/run_demo.py
+++ b/src/py/window_funcs/run_demo.py
@@ -5,7 +5,8 @@ PySpark Window Functions Demo Runner - CLI Interface for All Window Function Exa
 OVERVIEW:
 This CLI tool provides a convenient interface to run individual Window function demos
 by specifying use case labels. Each demo showcases different Window function patterns
-with comprehensive real-world business scenarios and production-ready code examples.
+with comprehensive real-world business scenarios and code examples.
+All demos are built using Spark Connect.
 
 KEY FEATURES:
 • Simple command-line interface for quick demo execution
@@ -13,6 +14,7 @@ KEY FEATURES:
 • Error handling and user-friendly feedback
 • Individual demo execution with progress tracking
 • List all available demos with business context
+• Spark Connect architecture
 
 AVAILABLE DEMOS:
 • ranking - Performance rankings and bonus calculations using ROW_NUMBER, RANK, DENSE_RANK
@@ -24,10 +26,11 @@ AVAILABLE DEMOS:
 
 BENEFITS:
 • Educational tool for learning Window functions with real examples
-• Production-ready code snippets for immediate implementation
-• Blog-ready examples with clear explanations
+• Code snippets with Spark Connect for immediate implementation
+• Examples with clear explanations and modern architecture
 • Quick iteration and testing of different Window function patterns
 • Professional development reference and training material
+• Spark Connect configuration for Spark 4.0+ environments
 
 Usage:
     python run_demo.py <use_case>
@@ -51,27 +54,27 @@ from pathlib import Path
 DEMOS = {
     'ranking': (
         'ranking_operations_demo.py',
-        'Ranking Operations: ROW_NUMBER, RANK, DENSE_RANK for performance analysis and bonus calculations'
+        'Ranking Operations: ROW_NUMBER, RANK, DENSE_RANK for performance analysis and bonus calculations (Spark Connect)'
     ),
     'aggregation': (
         'aggregation_window_demo.py',
-        'Running Aggregations: Cumulative totals, YTD tracking, and contribution analysis'
+        'Running Aggregations: Cumulative totals, YTD tracking, and contribution analysis (Spark Connect)'
     ),
     'lead_lag': (
         'lead_lag_demo.py',
-        'Lead/Lag Operations: Time series analysis, trend detection, and trading signals'
+        'Lead/Lag Operations: Time series analysis, trend detection, and trading signals (Spark Connect)'
     ),
     'moving_averages': (
         'moving_averages_demo.py',
-        'Moving Averages: Trend smoothing, performance monitoring, and noise reduction'
+        'Moving Averages: Trend smoothing, performance monitoring, and noise reduction (Spark Connect)'
     ),
     'percentile': (
         'percentile_analysis_demo.py',
-        'Percentile Analysis: Salary distributions, benchmarking, and statistical analysis'
+        'Percentile Analysis: Salary distributions, benchmarking, and statistical analysis (Spark Connect)'
     ),
     'first_last_value': (
         'first_last_value_demo.py',
-        'First/Last Value: Customer journey analysis, attribution modeling, and lifecycle tracking'
+        'First/Last Value: Customer journey analysis, attribution modeling, and lifecycle tracking (Spark Connect)'
     )
 }
 
@@ -131,8 +134,9 @@ def show_strategy_guide():
 
 def list_demos():
     """Display all available demos with descriptions"""
-    print("🎯 Available PySpark Window Function Demos:")
+    print("🎯 Available PySpark Window Function Demos (Spark Connect):")
     print("=" * 60)
+    print("\n⚡ All demos use Spark Connect!")
     print("\n💡 NEW: Check out WINDOW_FUNCTIONS_STRATEGY_GUIDE.md for help choosing the right approach!")
     print("   This comprehensive guide helps you select the optimal window function strategy")
     print("   for your specific business scenario with decision frameworks and examples.")
@@ -192,10 +196,10 @@ def run_demo(use_case):
 
 def main():
     parser = argparse.ArgumentParser(
-        description='PySpark Window Functions Demo Runner',
+        description='PySpark Window Functions Demo Runner (Spark Connect)',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Available Demo Use Cases:
+Available Demo Use Cases (All using Spark Connect):
   ranking          - Ranking operations (ROW_NUMBER, RANK, DENSE_RANK)
   aggregation      - Running totals and cumulative calculations  
   lead_lag         - Time series analysis with LAG/LEAD functions


### PR DESCRIPTION
Convert all 6 PySpark window function demos to use Spark Connect instead of traditional local Spark sessions.

Key Changes:
- Updated all demo files to use .config('spark.api.mode', 'connect').remote('local[*]')
- Removed SparkContext references (not available in Spark Connect)
- Updated README.md and run_demo.py documentation
- Added Spark Connect notes to all demo docstrings
- All demos tested and working correctly

Files Updated:
- ranking_operations_demo.py
- aggregation_window_demo.py  
- lead_lag_demo.py
- moving_averages_demo.py
- percentile_analysis_demo.py
- first_last_value_demo.py
- README.md
- run_demo.py

All existing functionality preserved while modernizing to Spark 4.0+ architecture.