### PR TITLE
feat: implement mixed API approach for Variant data processing

### DIFF
--- a/src/py/sc/variants/README.md
+++ b/src/py/sc/variants/README.md
@@ -91,16 +91,22 @@ SELECT AVG(VARIANT_GET(sensor_data, '$.wellhead_pressure', 'double')) as avg_pre
 FROM oil_rig_sensors WHERE sensor_type = 'pressure'
 ```
 
-**Key DataFrame Patterns**:
+**Key DataFrame Patterns (Mixed API Approach)**:
 ```python
-# Convert to Variant
-df_variant = df.select("*", parse_json("sensor_data_json").alias("sensor_data"))
+# Convert to Variant using DataFrame API
+from pyspark.sql.functions import col, parse_json, expr
+df_variant = df.select("*", parse_json(col("sensor_data_json")).alias("sensor_data"))
 
-# Extract and aggregate
+# Extract and aggregate using expr() for VARIANT_GET (no DataFrame equivalent)
 df_result = df_variant.agg(
     expr("AVG(VARIANT_GET(sensor_data, '$.wellhead_pressure', 'double'))").alias('avg_pressure')
 )
 ```
+
+**Why Mixed API?**
+- ✅ **parse_json()**: Available as DataFrame function
+- ❌ **VARIANT_GET()**: No DataFrame equivalent - use `expr()` with SQL
+- 🎯 **Best Practice**: Use DataFrame API where available, `expr()` for SQL-only functions
 
 ### 🛒 Module 2: E-commerce Events (Intermediate)
 
@@ -411,9 +417,15 @@ SELECT VARIANT_GET(event_data, '$.payment.method', 'string') as payment_method,
 FROM ecommerce_events WHERE event_type = 'purchase'
 ```
 
-### ✅ **DataFrame Expertise**
+### ✅ **DataFrame Expertise (Mixed API Mastery)**
 ```python
-# Seamless SQL-to-DataFrame conversion
+# Mixed API approach: DataFrame + SQL where needed
+from pyspark.sql.functions import col, parse_json, expr, count
+
+# Step 1: DataFrame API for JSON-to-Variant conversion
+df_variant = df.select(parse_json(col('json_col')).alias('variant_data'))
+
+# Step 2: expr() for VARIANT_GET (no DataFrame equivalent)
 df_result = df_variant.filter(col('sensor_type') == 'comprehensive').agg(
     expr("AVG(VARIANT_GET(sensor_data, '$.pressure.wellhead_pressure', 'double'))").alias('avg_pressure'),
     count('*').alias('reading_count')

--- a/src/py/sc/variants/sql_to_dataframe_example.py
+++ b/src/py/sc/variants/sql_to_dataframe_example.py
@@ -17,7 +17,7 @@ Authors: Jules S. Damji & Cursor AI
 """
 
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import avg, count, col, expr
+from pyspark.sql.functions import avg, count, col, expr, parse_json
 from pyspark.sql.dataframe import DataFrame
 from data_utility import generate_pressure_sensor_data
 import json
@@ -98,7 +98,8 @@ def demonstrate_sql_to_dataframe_conversion() -> None:
             col('sensor_id'),
             col('sensor_type'), 
             col('timestamp').cast('timestamp'),
-            expr('PARSE_JSON(sensor_data_json)').alias('sensor_data')  # Key conversion step
+            # Using DataFrame API: parse_json() is available as a native function
+            parse_json(col('sensor_data_json')).alias('sensor_data')  # Key conversion step
         )
         
         print("Schema after Variant conversion:")
@@ -138,6 +139,7 @@ def demonstrate_sql_to_dataframe_conversion() -> None:
         # Method 1: Direct translation using expr()
         print("\n🔹 Method 1: Direct Translation using expr()")
         print("Most direct conversion - uses expr() to embed SQL expressions")
+        print("Note: VARIANT_GET() has no DataFrame API equivalent, so we use expr() with SQL")
         
         df_method1 = df_with_variant \
             .filter(col('sensor_type') == 'pressure') \


### PR DESCRIPTION
- Update DataFrame API to use parse_json() for JSON-to-Variant conversion
- Add explanatory comments for mixed API usage (DataFrame + SQL via expr())
- Update README.md with mixed API best practices and examples
- Update developer_user_guide.md with comprehensive API selection guidance
- Document why VARIANT_GET() requires expr() (no DataFrame equivalent)
- Add new 'API Selection Best Practices' section to developer guide
- Maintain backward compatibility while showcasing modern patterns

All tests pass successfully with improved code clarity and documentation.